### PR TITLE
feat: add SymbolKind icons to C-g breadcrumb

### DIFF
--- a/config.nvim/lua/config/keymaps.lua
+++ b/config.nvim/lua/config/keymaps.lua
@@ -348,6 +348,9 @@ vim.keymap.set({ "n", "i", "x" }, "<C-G>", function()
       vim.print_silent("N.A.")
       return
     end
+    -- Resolve SymbolKind icon via lspkind (reuses cmp icon mappings)
+    local ok_lspkind, lspkind = pcall(require, "lspkind")
+    local symbol_map = ok_lspkind and lspkind.symbol_map or {}
     -- Walk the symbol tree to find the deepest symbol containing the cursor
     local cursor = vim.api.nvim_win_get_cursor(0)
     local row = cursor[1] - 1
@@ -356,7 +359,10 @@ vim.keymap.set({ "n", "i", "x" }, "<C-G>", function()
       for _, sym in ipairs(symbols) do
         local range = sym.range or sym.location and sym.location.range
         if range and range.start.line <= row and range["end"].line >= row then
-          table.insert(path, sym.name)
+          local kind_name = vim.lsp.protocol.SymbolKind[sym.kind] or ""
+          local icon = symbol_map[kind_name] or ""
+          local label = icon ~= "" and (icon .. " " .. sym.name) or sym.name
+          table.insert(path, label)
           if sym.children then walk(sym.children) end
           return
         end


### PR DESCRIPTION
## Summary

Add Nerd Font icons to the `<C-g>` breadcrumb output by reusing `lspkind.nvim`'s `symbol_map`.

## Before
```
MyClass > my_method
```

## After
```
󰠱 MyClass > 󰊕 my_method
```

## How it works

1. `sym.kind` (integer) → `vim.lsp.protocol.SymbolKind[kind]` → kind name (e.g. `"Class"`)
2. `require("lspkind").symbol_map["Class"]` → Nerd Font icon (e.g. `"󰠱"`)
3. `pcall` guarded — falls back to plain names if lspkind isn't loaded

No new dependencies — `lspkind.nvim` is already installed as a `nvim-cmp` dependency.