### PR TITLE
refactor(cmp): optimize sorting comparators and source priorities

### DIFF
--- a/config.nvim/lua/plugins/cmp.lua
+++ b/config.nvim/lua/plugins/cmp.lua
@@ -156,8 +156,12 @@ return {
         -- 3. Low priority: From other possible contents. Text, yanked text. Env var.
         sources = cmp.config.sources({
           {
+            name = "nvim_lsp",
+            priority = 100,
+          },
+          {
             name = "luasnip",
-            priority = 150,
+            priority = 90,
             option = {
               show_autosnippets = true,
               use_show_condition = false,
@@ -165,20 +169,16 @@ return {
           },
           {
             name = "async_path",
-            priority = 150,
-          },
-          {
-            name = "nvim_lsp",
-            priority = 150,
+            priority = 85,
           },
           {
             name = "nvim_lsp_signature_help",
-            priority = 150,
+            priority = 80,
             group_index = 1,
           },
           {
             name = "cmp_yanky",
-            priority = 130,
+            priority = 50,
             option = {
               minLength = 3,
               onlyCurrentFiletype = false,
@@ -186,7 +186,7 @@ return {
           },
           {
             name = "buffer",
-            priority = 120,
+            priority = 40,
           },
           {
             name = "nvim_lua",
@@ -196,7 +196,7 @@ return {
               end
               return true
             end,
-            priority = 110,
+            priority = 35,
             group_index = 1,
           },
           -- Temporarily removing dotenv.
@@ -224,7 +224,7 @@ return {
           -- },
           {
             name = "cmp_tabnine",
-            priority = 90,
+            priority = 30,
           },
           {
             max_item_count = 7,
@@ -233,13 +233,15 @@ return {
         sorting = {
           priority_weight = 2,
           comparators = {
-            cmp.config.compare.recently_used,
-            cmp.config.compare.kind,
-            cmp.config.compare.locality,
-            cmp.config.compare.score,
             cmp.config.compare.exact,
-            cmp.config.compare.offset,
+            cmp.config.compare.score,
+            cmp.config.compare.recently_used,
+            cmp.config.compare.locality,
+            cmp.config.compare.kind,
+            cmp.config.compare.sort_text,
             require("cmp-under-comparator").under,
+            cmp.config.compare.length,
+            cmp.config.compare.order,
           },
         },
         matching = {


### PR DESCRIPTION
## 改了什么

### Comparator 顺序重排

| 位置 | 改前 | 改后 | 理由 |
|------|------|------|------|
| 1 | `recently_used` | `exact` | 精确匹配应该永远排第一 |
| 2 | `kind` | `score` | 匹配质量是核心信号，不应被类型覆盖 |
| 3 | `locality` | `recently_used` | 历史选择做 tie-breaker，不做独裁者 |
| 4 | `score` | `locality` | 同分时光标附近的词优先 |
| 5 | `exact` | `kind` | 类型区分有用但不应压过匹配度 |
| 6 | `offset` | `sort_text` | 尊重 LSP 的排序建议（pyright/gopls 等） |
| 7 | `under` | `under` | 不变 |
| 8 | — | `length` | 短的优先（tie-breaker） |
| 9 | — | `order` | 稳定排序兜底 |

- 移除了 `offset`：它和 `score` 里的匹配逻辑重复
- 新增 `sort_text`：很多 LSP 会返回精心设计的 sortText
- 新增 `length` + `order`：更好的兜底

### Source Priority 拉开差距

之前 luasnip/async_path/nvim_lsp 全是 150，`priority_weight=2` 基本没用。

现在：
```
nvim_lsp(100) > luasnip(90) > path(85) > sig_help(80) > yanky(50) > buffer(40) > nvim_lua(35) > tabnine(30)
```

同时把 nvim_lsp 移到 sources 列表第一位。

### 预期改善

| 场景 | 改前 | 改后 |
|------|------|------|
| 输入 `len`，有变量 `len`(exact)，上次选过 `length` | `length` 排第一 ❌ | `len` 排第一 ✅ |
| 输入 `fmt.P`，LSP 给高分的 `Printf` 和低分但最近用过的 `Println` | `Println` 排第一 ❌ | `Printf` 排第一 ✅ |
| pyright 返回带 sortText 的建议 | sortText 被忽略 | 作为 tie-breaker 生效 |
| buffer 的词和 LSP 建议同等匹配 | priority 都是 150 无差异 | LSP(100) 明显优先于 buffer(40) |
