### PR TITLE
refactor(cmp): optimize sorting comparators and source priorities

### DIFF
--- a/config.nvim/lua/plugins/cmp.lua
+++ b/config.nvim/lua/plugins/cmp.lua
@@ -235,25 +235,12 @@ return {
         -- 3. Low priority: From other possible contents. Text, yanked text. Env var.
         sources = cmp.config.sources({
           {
-            name = "luasnip",
-            priority = 160,
-            option = {
-              show_autosnippets = true,
-              use_show_condition = true,
-            },
-          },
-          {
-            name = "async_path",
-            priority = 155,
-          },
-          {
             name = "nvim_lsp",
-            priority = 150,
+            priority = 100,
             -- Filter out snippet items from LSP when LuaSnip can handle them,
             -- to avoid duplicate snippet entries.
             entry_filter = function(entry, _)
               local kind = entry:get_kind()
-              -- Allow everything except Snippet kind from LSP when LuaSnip is active
               if kind == cmp.lsp.CompletionItemKind.Snippet then
                 return false
               end
@@ -261,13 +248,25 @@ return {
             end,
           },
           {
+            name = "luasnip",
+            priority = 90,
+            option = {
+              show_autosnippets = true,
+              use_show_condition = true,
+            },
+          },
+          {
+            name = "async_path",
+            priority = 85,
+          },
+          {
             name = "nvim_lsp_signature_help",
-            priority = 150,
+            priority = 80,
             group_index = 1,
           },
           {
             name = "cmp_yanky",
-            priority = 100,
+            priority = 50,
             option = {
               minLength = 3,
               onlyCurrentFiletype = false,
@@ -275,7 +274,7 @@ return {
           },
           {
             name = "buffer",
-            priority = 90,
+            priority = 40,
             option = {
               -- Only get completions from visible buffers to limit noise
               get_bufnrs = function()
@@ -295,7 +294,7 @@ return {
               end
               return true
             end,
-            priority = 110,
+            priority = 35,
             group_index = 1,
           },
           -- Temporarily removing dotenv.
@@ -328,24 +327,28 @@ return {
         sorting = {
           priority_weight = 2,
           comparators = {
-            -- 1. Recently used items first
-            cmp.config.compare.recently_used,
+            -- 1. Exact matches always win
+            cmp.config.compare.exact,
             -- 2. Prefer prefix matches over fuzzy
             prefix_match_comparator,
-            -- 3. Exact matches
-            cmp.config.compare.exact,
-            -- 4. Locality-aware: prefer variables/fields, prefer local sources
-            locality_bonus_comparator,
-            -- 5. LSP-provided sort order
+            -- 3. Match quality (includes source priority weighting)
             cmp.config.compare.score,
-            -- 6. Kind-based ordering (variables > functions > keywords)
-            cmp.config.compare.kind,
-            -- 7. Proximity in buffer
+            -- 4. Recently used as tie-breaker, not dictator
+            cmp.config.compare.recently_used,
+            -- 5. Prefer variables/fields, prefer local sources
+            locality_bonus_comparator,
+            -- 6. Proximity in buffer
             cmp.config.compare.locality,
-            -- 8. Offset-based ordering
-            cmp.config.compare.offset,
+            -- 7. Kind-based ordering (variables > functions > keywords > text)
+            cmp.config.compare.kind,
+            -- 8. LSP-provided sort text
+            cmp.config.compare.sort_text,
             -- 9. Underscore items last
             require("cmp-under-comparator").under,
+            -- 10. Shorter labels preferred
+            cmp.config.compare.length,
+            -- 11. Stable sort fallback
+            cmp.config.compare.order,
           },
         },
         matching = {


### PR DESCRIPTION
## 改了什么

基于 nightly 分支，保留了自定义的 `prefix_match_comparator` 和 `locality_bonus_comparator`。

### Comparator 顺序重排

| 位置 | 改前 | 改后 | 理由 |
|------|------|------|------|
| 1 | `recently_used` | `exact` | 精确匹配应该永远排第一 |
| 2 | `prefix_match` | `prefix_match` | 不变，前缀匹配 > 模糊匹配 |
| 3 | `exact` | `score` | 匹配质量（含 source priority 加权）是核心信号 |
| 4 | `locality_bonus` | `recently_used` | 历史选择降为 tie-breaker |
| 5 | `score` | `locality_bonus` | 自定义的局部性/类型偏好 |
| 6 | `kind` | `locality` | 光标附近的词优先 |
| 7 | `locality` | `kind` | 类型区分有用但不应压过匹配度 |
| 8 | `offset` | `sort_text` | 尊重 LSP 的 sortText（pyright/gopls 等） |
| 9 | `under` | `under` | 不变 |
| 10 | — | `length` | 短的优先（tie-breaker） |
| 11 | — | `order` | 稳定排序兜底 |

- 移除了 `offset`：和 `score` 重复
- 新增 `sort_text`/`length`/`order`

### Source Priority 拉开差距

之前 luasnip(160)/path(155)/lsp(150) 差距太小。

现在：
```
nvim_lsp(100) > luasnip(90) > path(85) > sig_help(80) > yanky(50) > buffer(40) > nvim_lua(35)
```

nvim_lsp 移到 sources 列表第一位。

### 预期改善

| 场景 | 改前 | 改后 |
|------|------|------|
| 输入 `len`，有变量 `len`(exact)，上次选过 `length` | `length` 排第一 ❌ | `len` 排第一 ✅ |
| 输入 `fmt.P`，LSP 给高分 `Printf` 和低分但 recently used 的 `Println` | `Println` 排第一 ❌ | `Printf` 排第一 ✅ |
| pyright 返回带 sortText 的建议 | sortText 被忽略 | 作为 tie-breaker 生效 ✅ |
| buffer 词和 LSP 建议同等匹配 | priority 差距小 | LSP(100) 明显优先于 buffer(40) ✅ |
