### PR TITLE
feat: Mason → Nix tool migration (#38)

### DIFF
--- a/config.nvim/lua/config/autocmds.lua
+++ b/config.nvim/lua/config/autocmds.lua
@@ -33,7 +33,8 @@ vim.api.nvim_create_user_command("DebugServe", function(opt)
   require("osv").launch({ port = port })
 end, { nargs = "?" })
 
--- Mason
+-- Mason (skip in Nix environment — tools are provided by Nix)
+if vim.g.nixCats == nil then
 vim.api.nvim_create_user_command("MasonInstallAll", function(opts)
   local ensure_installed = require("mason").ensure_installed
 
@@ -74,6 +75,7 @@ end, {
   desc = "Demand mason to install all the dependencies defined by `mason.ensure_installed`.",
   nargs = "?",
 })
+end -- if not is_nix
 
 -- Open the launch.json related to the current workdir. If non-exists, confirms to create.
 vim.api.nvim_create_user_command("OpenLaunchJson", function()

--- a/config.nvim/lua/config/commands.lua
+++ b/config.nvim/lua/config/commands.lua
@@ -289,7 +289,8 @@ vim.api.nvim_create_user_command("DebugServe", function(opt)
   require("osv").launch({ port = port })
 end, { nargs = "?" })
 
--- Mason
+-- Mason (skip in Nix environment — tools are provided by Nix)
+if vim.g.nixCats == nil then
 vim.api.nvim_create_user_command("MasonInstallAll", function(opts)
   local ensure_installed = require("mason").ensure_installed
 
@@ -328,6 +329,7 @@ end, {
   desc = "Demand mason to install all the dependencies defined by `mason.ensure_installed`.",
   nargs = "?",
 })
+end -- if not is_nix
 
 -- Open the launch.json related to the current workdir.
 vim.api.nvim_create_user_command("OpenLaunchJson", function()

--- a/config.nvim/lua/plugins/debug.lua
+++ b/config.nvim/lua/plugins/debug.lua
@@ -619,6 +619,8 @@ return {
       -- DAP Adapters Registration
       -- ============================================================
 
+      local is_nix = vim.g.nixCats ~= nil
+
       ---@param name string
       ---@param exe_name? string
       local function dap_register_if_executable(name, exe_name)
@@ -633,7 +635,29 @@ return {
         end
       end
       dap_register_if_executable("cppdbg", "OpenDebugAD7")
-      dap_register_if_executable("codelldb")
+
+      -- codelldb: In Nix, it may not be directly on PATH as "codelldb".
+      -- The extension provides adapter/codelldb inside the extension dir.
+      if is_nix then
+        local ext_path = vim.env.CODELLDB_EXTENSION_PATH
+        if ext_path and ext_path ~= "" then
+          local codelldb_bin = ext_path .. "/adapter/codelldb"
+          if vim.fn.executable(codelldb_bin) == 1 then
+            dap.adapters.codelldb = {
+              id = "codelldb",
+              type = "server",
+              port = "${port}",
+              executable = {
+                command = codelldb_bin,
+                args = { "--port", "${port}" },
+              },
+            }
+          end
+        end
+      else
+        dap_register_if_executable("codelldb")
+      end
+
       dap_register_if_executable("gopls")
       dap_register_if_executable("sh", "bash-debug-adapter")
 

--- a/config.nvim/lua/plugins/go.lua
+++ b/config.nvim/lua/plugins/go.lua
@@ -13,6 +13,7 @@ return {
     end,
     event = { "CmdlineEnter" },
     ft = { "go", "gomod" },
-    build = ':lua require("go.install").update_all_sync()', -- if you need to install/update all binaries
+    -- In Nix, Go tools are provided by Nix; skip Mason/go.install build step.
+    build = (vim.g.nixCats ~= nil) and nil or ':lua require("go.install").update_all_sync()',
   },
 }

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -1,6 +1,14 @@
+-- Detect nixCats Nix environment.
+-- In Nix, tools (LSPs, formatters, linters) are provided on PATH by Nix;
+-- Mason is not needed and should be skipped.
+-- In non-Nix environments, Mason manages everything as before.
+local is_nix = vim.g.nixCats ~= nil
+
 return {
   {
     "williamboman/mason.nvim",
+    -- In Nix environment, disable Mason entirely: tools come from Nix PATH.
+    enabled = not is_nix,
     cmd = {
       "Mason",
       "MasonInstall",

--- a/config.nvim/lua/plugins/rust.lua
+++ b/config.nvim/lua/plugins/rust.lua
@@ -48,17 +48,30 @@ return {
       },
     },
     config = function()
+      local is_nix = vim.g.nixCats ~= nil
+
       vim.g.rustaceanvim = function()
         local cfg = require('rustaceanvim.config')
-        -- Check if installed by mason.
+        -- Determine codelldb extension path.
         local extension_path = ""
+
         if vim.g.codelldb_extension_path and vim.g.codelldb_extension_path ~= "" then
+          -- User-provided path takes priority.
           extension_path = vim.g.codelldb_extension_path
-        elseif require("mason-registry").is_installed("codelldb") then
-          extension_path = vim.fn.stdpath("data") .. "/mason/packages/codelldb/extension"
+        elseif is_nix then
+          -- In Nix environment, use the path exposed via environment variable.
+          local env_path = vim.env.CODELLDB_EXTENSION_PATH
+          if env_path and env_path ~= "" then
+            extension_path = env_path .. "/"
+          else
+            vim.notify("nixCats: CODELLDB_EXTENSION_PATH not set. Debug may not work.", vim.log.levels.WARN)
+          end
+        elseif pcall(require, "mason-registry") and require("mason-registry").is_installed("codelldb") then
+          extension_path = vim.fn.stdpath("data") .. "/mason/packages/codelldb/extension/"
         else
-          vim.notify("codelldb not installed by Mason. Please point by vim.g.codelldb_extension_path")
+          vim.notify("codelldb not found. Install via Mason or set vim.g.codelldb_extension_path", vim.log.levels.WARN)
         end
+
         local codelldb_path = extension_path .. 'adapter/codelldb'
         local liblldb_path = extension_path .. 'lldb/lib/liblldb'
         local this_os = vim.uv.os_uname().sysname;

--- a/flake.nix
+++ b/flake.nix
@@ -150,25 +150,39 @@
           rust-analyzer
           gopls
           pyright
-          ruff
-          clangd
-          nil  # nix LSP
-          nodePackages.vscode-json-languageserver
+          ruff                    # linter + formatter
+          clang-tools             # provides clangd (and clang-format)
+          nil                     # Nix LSP
+          vscode-langservers-extracted  # JSON/HTML/CSS/ESLint language servers
           yaml-language-server
-          taplo  # TOML LSP
+          taplo                   # TOML LSP
+          cmake-language-server
+          checkmake               # Makefile linter
         ];
         formatters = with pkgs; [
           stylua
           gofumpt
-          gotools          # provides goimports
+          gotools                 # provides goimports
           nixfmt-rfc-style
+          nixpkgs-fmt
+          # clang-tools already in lsp (provides clang-format)
+          python3Packages.cmakelang  # cmake-format + cmake-lint
+          python3Packages.black
+          # rustfmt comes with the Rust toolchain
+          fixjson
+          python3Packages.xmlformatter
+          shfmt
+          gomodifytags
+          impl                    # Go interface implementation generator
+        ];
+        linters = with pkgs; [
+          nodePackages.jsonlint
+          # cmakelang already in formatters (provides cmake-lint)
         ];
         debug = with pkgs; [
           delve                     # Go debugger
           python3Packages.debugpy   # Python debug adapter
-        ] ++ (with pkgs.vscode-extensions.vadimcn; [
-          vscode-lldb               # codelldb for Rust/C/C++
-        ]);
+        ];
       };
 
       # ── Startup plugins (always loaded) ─────────────────────────────────
@@ -292,7 +306,13 @@
       };
 
       # ── Environment variables ───────────────────────────────────────────
-      environmentVariables = {};
+      environmentVariables = {
+        debug = {
+          # Expose codelldb extension path so Lua config can find the adapter binary.
+          # The extension layout is: <ext>/adapter/codelldb and <ext>/lldb/lib/liblldb.so
+          CODELLDB_EXTENSION_PATH = "${pkgs.vscode-extensions.vadimcn.vscode-lldb}/share/vscode/extensions/vadimcn.vscode-lldb";
+        };
+      };
 
       # ── Extra Lua packages ──────────────────────────────────────────────
       extraLuaPackages = {
@@ -318,6 +338,7 @@
           general = true;
           lsp = true;
           formatters = true;
+          linters = true;
           debug = true;
           ai = true;
           core = true;


### PR DESCRIPTION
## Summary

Complete the Mason → Nix tool migration for the nixCats integration (Issue #38).

In Nix environments, all LSP servers, formatters, linters, and DAP adapters are provided by Nix packages on PATH. Mason is disabled entirely. In non-Nix environments, nothing changes — Mason continues to manage everything as before.

## Changes

### flake.nix
- **LSP servers:** Added cmake-language-server, checkmake. Switched to `clang-tools` (provides clangd + clang-format) and `vscode-langservers-extracted` (JSON/HTML/CSS LSPs).
- **Formatters:** Added nixpkgs-fmt, cmakelang (cmake-format + cmake-lint), black, fixjson, xmlformatter, shfmt, gomodifytags, impl.
- **Linters:** New category with jsonlint.
- **DAP:** Exposed `CODELLDB_EXTENSION_PATH` environment variable so Lua config can find the codelldb adapter binary from the Nix store.

### Lua config
- **lsp.lua:** Mason plugin disabled in Nix via `enabled = not is_nix`. All `lspconfig` server setups remain active in both environments.
- **rust.lua:** Nix-aware codelldb path resolution using `CODELLDB_EXTENSION_PATH` env var. Mason-registry require guarded with pcall.
- **debug.lua:** Nix-specific codelldb DAP adapter registration (server mode with extension path).
- **go.lua:** Skip `go.install` build step in Nix.
- **autocmds.lua / commands.lua:** `MasonInstallAll` command wrapped in Nix guard.

### Design
- All changes gated on `vim.g.nixCats ~= nil`
- Non-Nix environments completely unaffected
- conform.nvim and nvim-lint unchanged (they find tools on PATH regardless)

Closes #38