### PR TITLE
fix(lsp): remove yamlls config conflict for Neovim 0.12

### DIFF
--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -135,9 +135,9 @@ return {
         tex = {
           -- "texlab",
         },
-        yaml = {
-          "yaml-language-server",
-        },
+        -- yaml = {
+        --   "yaml-language-server",  -- Handled by LazyVim extra
+        -- },
         xml = {
           "lemminx",
           "xmlformatter",
@@ -234,8 +234,8 @@ return {
       -- docker/docker-compose
       lspconfig.docker_compose_language_service.setup({})
       lspconfig.dockerls.setup({})
-      -- yaml
-      lspconfig.yamlls.setup({})
+      -- yaml: Handled by LazyVim extra (lazyvim.plugins.extras.lang.yaml)
+      -- Do NOT call lspconfig.yamlls.setup() here - it conflicts with LazyVim's config
       -- rust
       -- lspconfig.rust_analyzer.setup({}) -- Rust analyzer configured by rustaceanvim. If enabled, there will be two lsps.
       -- python


### PR DESCRIPTION
## Summary

Remove manual `lspconfig.yamlls.setup({})` which conflicts with LazyVim's yaml extra.

## Problem

This conflict causes `E518: Unknown option` errors when opening YAML files due to the doautoall bug in Neovim 0.11.5's `vim.lsp.enable()` function.

## Solution

- Remove manual yamlls setup from `lua/plugins/lsp.lua`
- Remove yaml mason entry (LazyVim extra handles it)
- Add comments explaining why manual setup should not be added

## Related

- Fixes #48
- Related: neovim/neovim#36518