### PR TITLE
feat: switch treesitter highlight from whitelist to blacklist mode

### DIFF
--- a/config.nvim/lua/config/autocmds.lua
+++ b/config.nvim/lua/config/autocmds.lua
@@ -590,16 +590,18 @@ end
 vim.api.nvim_create_autocmd("FileType", {
   pattern = { "*" },
   callback = function()
-    if vim.tbl_contains(vim.g.use_treesitter_highlight, vim.bo.filetype) then
+    if not vim.tbl_contains(vim.g.treesitter_highlight_blacklist or {}, vim.bo.filetype) then
       -- Neovim 0.12: :TSBufEnable was removed; use built-in API.
       -- Enable vim regex highlighting alongside treesitter to preserve
       -- the previous additional_vim_regex_highlighting = true behavior.
       local ok = pcall(vim.treesitter.start)
       if ok then
         vim.bo.syntax = "on"
+      else
+        vim.bo.syntax = "on" -- fallback to regex highlight
       end
     else
-      vim.bo.syntax = "on"
+      vim.bo.syntax = "on" -- blacklisted, use regex only
     end
   end,
 })

--- a/config.nvim/lua/config/options.lua
+++ b/config.nvim/lua/config/options.lua
@@ -69,7 +69,7 @@ vim.cmd([[ set cmdheight=0 noshowmode noruler noshowcmd ]])
 
 -- Highlighting Source.
 vim.cmd([[ syntax off ]])                       -- we won't need syntax anytime. Use treesitter at least.
-vim.g.use_treesitter_highlight = { "c", "cpp" }
+vim.g.treesitter_highlight_blacklist = {}
 
 -- Undo history even when the file is closed.
 vim.opt.undofile = true


### PR DESCRIPTION
## Summary

Switches treesitter highlighting from **whitelist** mode to **blacklist** mode, as requested in #51.

### Changes

#### `config.nvim/lua/config/options.lua`
- Replaced `vim.g.use_treesitter_highlight = { "c", "cpp" }` (whitelist) with `vim.g.treesitter_highlight_blacklist = {}` (blacklist, default empty)

#### `config.nvim/lua/config/autocmds.lua`  
- Updated the `FileType` autocmd logic: treesitter highlighting is now **enabled for all filetypes by default**, except those listed in `vim.g.treesitter_highlight_blacklist`
- Added fallback comment for clarity when `pcall(vim.treesitter.start)` fails or filetype is blacklisted

### Behavior
- **Default**: all filetypes get treesitter highlighting
- **To exclude a filetype**: add it to `vim.g.treesitter_highlight_blacklist`, e.g. `vim.g.treesitter_highlight_blacklist = { "markdown", "help" }`
- Large file handling is already managed by the bigfiles plugin, so no special handling needed here

Closes #51