### PR TITLE
fix: improve YAML file support (#57)

### DIFF
--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -113,6 +113,8 @@ return {
         },
         yaml = {
           "yaml-language-server",
+          "yamllint",
+          "prettier",
         },
         xml = {
           "lemminx",

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -144,29 +144,59 @@ return {
       { "nvim-treesitter/nvim-treesitter" },
     },
     config = function()
-      -- Neovim 0.12 / nvim-treesitter main branch:
-      -- nvim-treesitter.configs is removed; use the new direct API.
-      require("nvim-treesitter-textobjects").setup({
-        select = {
-          lookahead = true,
-          include_surrounding_whitespace = true,
-        },
-      })
+      -- nvim-treesitter-textobjects setup: the new version (851e865+) exposes
+      -- a top-level .setup() function; older versions only work through
+      -- nvim-treesitter.configs.  Guard the call so both paths work and a
+      -- stale install doesn't crash on startup.
+      local ts_textobjects = require("nvim-treesitter-textobjects")
+      if type(ts_textobjects.setup) == "function" then
+        ts_textobjects.setup({
+          select = {
+            lookahead = true,
+            include_surrounding_whitespace = true,
+          },
+        })
+      else
+        -- Fallback for older plugin versions that use the configs module
+        local ok, ts_configs = pcall(require, "nvim-treesitter.configs")
+        if ok then
+          ts_configs.setup({
+            textobjects = {
+              select = {
+                enable = true,
+                lookahead = true,
+                include_surrounding_whitespace = true,
+                keymaps = {
+                  ["af"] = "@function.outer",
+                  ["if"] = "@function.inner",
+                  ["ac"] = "@class.outer",
+                  ["ic"] = "@class.inner",
+                },
+              },
+            },
+          })
+        else
+          vim.notify("nvim-treesitter-textobjects: could not configure (version mismatch)", vim.log.levels.WARN)
+        end
+      end
 
-      -- Textobject keymaps (previously configured via nvim-treesitter.configs)
-      local select_textobject = require("nvim-treesitter-textobjects.select").select_textobject
-      vim.keymap.set({ "x", "o" }, "af", function()
-        select_textobject("@function.outer", "textobjects")
-      end, { desc = "Select outer function" })
-      vim.keymap.set({ "x", "o" }, "if", function()
-        select_textobject("@function.inner", "textobjects")
-      end, { desc = "Select inner function" })
-      vim.keymap.set({ "x", "o" }, "ac", function()
-        select_textobject("@class.outer", "textobjects")
-      end, { desc = "Select outer class" })
-      vim.keymap.set({ "x", "o" }, "ic", function()
-        select_textobject("@class.inner", "textobjects")
-      end, { desc = "Select inner class" })
+      -- Textobject keymaps (for new-style direct API)
+      local sel_ok, sel_mod = pcall(require, "nvim-treesitter-textobjects.select")
+      local select_textobject = sel_ok and sel_mod.select_textobject or nil
+      if select_textobject then
+        vim.keymap.set({ "x", "o" }, "af", function()
+          select_textobject("@function.outer", "textobjects")
+        end, { desc = "Select outer function" })
+        vim.keymap.set({ "x", "o" }, "if", function()
+          select_textobject("@function.inner", "textobjects")
+        end, { desc = "Select inner function" })
+        vim.keymap.set({ "x", "o" }, "ac", function()
+          select_textobject("@class.outer", "textobjects")
+        end, { desc = "Select outer class" })
+        vim.keymap.set({ "x", "o" }, "ic", function()
+          select_textobject("@class.inner", "textobjects")
+        end, { desc = "Select inner class" })
+      end
 
       -- Incremental selection (Tab/Shift-Tab) — replaces the removed
       -- nvim-treesitter incremental_selection module.

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -353,6 +353,7 @@ return {
         -- lua = { "luacheck" },
         -- markdown = { "markdownlint-cli2" },
         python = { "ruff" },
+        yaml = { "yamllint" },
         sql = { "sqlfluff" },
         -- go = { "gopls" },
       }

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -402,6 +402,7 @@ return {
           golang = { "goimports", "gopls" },
           rust = { "rustfmt", lsp_format = "fallback" },
           json = { "fixjson" },
+          yaml = { "prettier", lsp_format = "fallback" },
           xml = { "xmlformatter" },
           bash = { "shfmt" },
           -- Conform will run the first available formatter

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -255,7 +255,21 @@ return {
       lspconfig.docker_compose_language_service.setup({})
       lspconfig.dockerls.setup({})
       -- yaml
-      lspconfig.yamlls.setup({})
+      lspconfig.yamlls.setup({
+        capabilities = cmp_nvim_lsp.default_capabilities(),
+        settings = {
+          yaml = {
+            schemaStore = {
+              enable = true,
+              url = "https://www.schemastore.org/api/json/catalog.json",
+            },
+            format = { enable = true },
+            validate = true,
+            hover = true,
+            completion = true,
+          },
+        },
+      })
       -- python
       lspconfig.pyright.setup({})
       -- nix

--- a/tests/test_yaml_support.lua
+++ b/tests/test_yaml_support.lua
@@ -1,0 +1,130 @@
+-- test_yaml_support.lua
+-- Validates YAML support fixes for issue #57
+-- Run: nvim --headless -u NORC -l tests/test_yaml_support.lua
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    passed = passed + 1
+    print("  ✅ " .. name)
+  else
+    failed = failed + 1
+    print("  ❌ " .. name .. ": " .. tostring(err))
+  end
+end
+
+print("\n=== YAML Support Tests ===\n")
+
+-- We test the Lua source files directly (static analysis) since we can't
+-- load the full plugin stack in headless mode without all dependencies.
+
+local lsp_path = "config.nvim/lua/plugins/lsp.lua"
+local lsp_src = io.open(lsp_path, "r")
+assert(lsp_src, "Cannot open " .. lsp_path)
+local lsp_code = lsp_src:read("*a")
+lsp_src:close()
+
+-- P1: yamlls has capabilities and settings
+test("yamlls setup includes cmp_nvim_lsp capabilities", function()
+  assert(lsp_code:find("yamlls%.setup"), "yamlls.setup not found")
+  -- Find the yamlls setup block
+  local setup_start = lsp_code:find("yamlls%.setup")
+  local after_setup = lsp_code:sub(setup_start, setup_start + 600)
+  assert(after_setup:find("cmp_nvim_lsp%.default_capabilities"),
+    "yamlls setup missing cmp_nvim_lsp.default_capabilities()")
+end)
+
+test("yamlls setup includes schemaStore settings", function()
+  local setup_start = lsp_code:find("yamlls%.setup")
+  local after_setup = lsp_code:sub(setup_start, setup_start + 600)
+  assert(after_setup:find("schemaStore"), "yamlls setup missing schemaStore settings")
+  assert(after_setup:find("schemastore%.org"), "yamlls setup missing schemaStore URL")
+end)
+
+test("yamlls setup includes format, validate, hover, completion", function()
+  local setup_start = lsp_code:find("yamlls%.setup")
+  local after_setup = lsp_code:sub(setup_start, setup_start + 600)
+  assert(after_setup:find('format%s*=%s*{%s*enable%s*=%s*true'), "yamlls missing format.enable")
+  assert(after_setup:find('validate%s*=%s*true'), "yamlls missing validate")
+  assert(after_setup:find('hover%s*=%s*true'), "yamlls missing hover")
+  assert(after_setup:find('completion%s*=%s*true'), "yamlls missing completion")
+end)
+
+-- P2: textobjects setup is guarded
+test("textobjects setup is guarded with type check", function()
+  assert(lsp_code:find('type%(ts_textobjects%.setup%)%s*==%s*"function"')
+      or lsp_code:find("type%(ts_textobjects.setup%)"),
+    "textobjects setup not guarded with type check")
+end)
+
+test("textobjects has fallback for old nvim-treesitter.configs", function()
+  assert(lsp_code:find('nvim%-treesitter%.configs'),
+    "textobjects missing fallback to nvim-treesitter.configs")
+end)
+
+-- P3: conform has yaml formatter
+test("conform formatters_by_ft includes yaml", function()
+  -- Look for yaml in formatters_by_ft
+  local fmt_start = lsp_code:find("formatters_by_ft")
+  assert(fmt_start, "formatters_by_ft not found")
+  local fmt_block = lsp_code:sub(fmt_start, fmt_start + 800)
+  assert(fmt_block:find('yaml%s*='), "yaml not in formatters_by_ft")
+end)
+
+test("conform yaml formatter uses lsp_format fallback", function()
+  local fmt_start = lsp_code:find("formatters_by_ft")
+  local fmt_block = lsp_code:sub(fmt_start, fmt_start + 800)
+  -- Find yaml line and check for lsp_format
+  local yaml_pos = fmt_block:find('yaml%s*=')
+  assert(yaml_pos, "yaml entry not found")
+  local yaml_line = fmt_block:sub(yaml_pos, yaml_pos + 100)
+  assert(yaml_line:find('lsp_format'), "yaml formatter missing lsp_format fallback")
+end)
+
+-- P4: nvim-lint has yaml linter
+test("nvim-lint linters_by_ft includes yaml with yamllint", function()
+  local lint_start = lsp_code:find("linters_by_ft")
+  assert(lint_start, "linters_by_ft not found")
+  local lint_block = lsp_code:sub(lint_start, lint_start + 1000)
+  -- Check yaml entry exists with yamllint
+  assert(lint_block:find('yaml') and lint_block:find('yamllint'),
+    "yaml with yamllint not in linters_by_ft")
+end)
+
+-- P5: Mason ensure_installed includes yaml-language-server
+test("Mason ensure_installed has yaml-language-server", function()
+  assert(lsp_code:find('"yaml%-language%-server"'),
+    "yaml-language-server not in Mason ensure_installed")
+end)
+
+test("Mason ensure_installed has yamllint", function()
+  assert(lsp_code:find('"yamllint"'),
+    "yamllint not in Mason ensure_installed")
+end)
+
+test("Mason ensure_installed has prettier", function()
+  assert(lsp_code:find('"prettier"'),
+    "prettier not in Mason ensure_installed")
+end)
+
+-- Treesitter ensure_installed includes yaml
+local misc_path = "config.nvim/lua/plugins/miscellaneous.lua"
+local misc_src = io.open(misc_path, "r")
+assert(misc_src, "Cannot open " .. misc_path)
+local misc_code = misc_src:read("*a")
+misc_src:close()
+
+test("treesitter ensure_installed includes yaml", function()
+  local ei_start = misc_code:find("ensure_installed")
+  assert(ei_start, "ensure_installed not found in miscellaneous.lua")
+  local ei_block = misc_code:sub(ei_start, ei_start + 1000)
+  assert(ei_block:find('"yaml"'), "yaml not in treesitter ensure_installed")
+end)
+
+print(string.format("\n=== Results: %d passed, %d failed ===\n", passed, failed))
+if failed > 0 then
+  os.exit(1)
+end


### PR DESCRIPTION
## Summary

Fixes #57 — Comprehensive improvements to YAML file support.

## Changes

### P1: yamlls LSP configuration (lsp.lua)
- Added `cmp_nvim_lsp.default_capabilities()` for enhanced completion
- Added SchemaStore integration for automatic JSON schema association (Kubernetes, GitHub Actions, Docker Compose, etc.)
- Enabled built-in formatting, validation, hover, and completion settings

### P2: textobjects setup crash guard (lsp.lua)
- Wrapped `nvim-treesitter-textobjects` `.setup()` call with version detection
- Added fallback to old `nvim-treesitter.configs` pattern for older plugin versions
- Guarded keymap registration to prevent errors when select module is unavailable
- Prevents the `attempt to call field 'setup' (a nil value)` crash

### P3: YAML formatter (conform)
- Added `yaml = { "prettier", lsp_format = "fallback" }` to `formatters_by_ft`
- Uses prettier as primary formatter, falls back to yamlls built-in formatting

### P4: YAML linter (nvim-lint)
- Added `yaml = { "yamllint" }` to `linters_by_ft`

### P5: Mason ensure_installed (mason)
- Added `yamllint` and `prettier` to the yaml section
- `yaml-language-server` was already listed; now the full toolchain is covered

### Note on treesitter parser
- `yaml` is already in treesitter `ensure_installed` — the missing parser is a runtime issue requiring `:TSUpdate` or `:TSInstall yaml`

## Tests

All 12 static analysis tests pass (`lua tests/test_yaml_support.lua`):
- ✅ yamlls capabilities and schema settings
- ✅ textobjects setup guard and fallback
- ✅ conform yaml formatter with lsp_format fallback
- ✅ nvim-lint yaml linter (yamllint)
- ✅ Mason ensure_installed yaml toolchain
- ✅ treesitter ensure_installed includes yaml