### PR TITLE
fix: consolidate bigfile handling into Snacks, remove LunarVim/bigfile.nvim (#57)

### DIFF
--- a/config.nvim/lua/plugins/bigfile.lua
+++ b/config.nvim/lua/plugins/bigfile.lua
@@ -127,8 +127,9 @@ local function disable_expensive_features(bufnr, reason)
   end)
 
   -- Disable matchparen — MUST be in vim.schedule to avoid E201 (#57)
+  -- (windo inside NoMatchParen iterates picker floats → changes curbuf → E201)
   vim.schedule(function()
-    if vim.fn.exists(":NoMatchParen") ~= 0 then
+    if vim.api.nvim_buf_is_valid(bufnr) and vim.fn.exists(":NoMatchParen") ~= 0 then
       vim.cmd("NoMatchParen")
     end
   end)

--- a/config.nvim/lua/plugins/bigfile.lua
+++ b/config.nvim/lua/plugins/bigfile.lua
@@ -1,6 +1,13 @@
--- Big file and binary file handling.
--- When opening large files or binary files, automatically disable expensive features
--- to keep Neovim responsive. Addresses nvim-config#3.
+-- Big file and binary file handling (supplementary to Snacks bigfile).
+--
+-- Snacks bigfile handles size-based detection (>1MB) with filetype override
+-- and the `setup` callback (see miscellaneous.lua). This file provides:
+--   1. Binary file detection (by extension and content analysis)
+--   2. BufReadPre precheck for extremely large files (>10MB)
+--   3. BigFileInfo / BigFileOverride user commands
+--
+-- Fixes nvim-config#57: NoMatchParen is always called inside vim.schedule()
+-- to avoid E201 when Snacks picker floating windows are present.
 
 ---@param bytes number
 ---@return string
@@ -16,159 +23,145 @@ local function format_size(bytes)
   end
 end
 
+-- Size threshold in bytes (default 1MB, matches Snacks bigfile.size)
+local bigfile_size_threshold = vim.g.bigfile_size_threshold or (1024 * 1024) -- 1 MB
+
+-- Binary file extensions to always treat as big/binary
+local binary_extensions = {
+  "bin", "o", "obj", "exe", "a", "so", "dylib", "dll",
+  "class", "pyc", "pyo",
+  "pdf", "doc", "docx", "xls", "xlsx",
+  "png", "jpg", "jpeg", "gif", "bmp", "ico", "webp",
+  "mp3", "mp4", "avi", "mkv", "mov", "flv", "wmv", "wav", "flac",
+  "zip", "tar", "gz", "bz2", "xz", "7z", "rar",
+  "wasm", "dat",
+}
+
+--- Check if a buffer contains binary content (null bytes in first lines)
+---@param bufnr number
+---@return boolean
+local function is_binary_content(bufnr)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, 0, math.min(100, line_count), false)
+  if not ok then
+    return false
+  end
+  for _, line in ipairs(lines) do
+    if line:find("%z") then
+      return true
+    end
+    -- Check for high concentration of non-printable characters
+    local total = #line
+    if total > 0 then
+      local check_len = math.min(total, 512)
+      local non_printable = 0
+      for i = 1, check_len do
+        local byte = line:byte(i)
+        if byte < 32 and byte ~= 9 and byte ~= 10 and byte ~= 13 then
+          non_printable = non_printable + 1
+        end
+      end
+      if non_printable / check_len > 0.3 then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+--- Check if file extension is a known binary type
+---@param filepath string
+---@return boolean
+local function is_binary_extension(filepath)
+  local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
+  return vim.tbl_contains(binary_extensions, ext)
+end
+
+--- Disable expensive features for a binary file buffer.
+--- This is only called for binary detection (Snacks bigfile handles size-based cases).
+--- NOTE: NoMatchParen MUST be in vim.schedule to avoid E201 (#57).
+---@param bufnr number
+---@param reason string
+local function disable_expensive_features(bufnr, reason)
+  vim.b[bufnr].bigfile_detected = true
+  vim.b[bufnr].bigfile_reason = reason
+
+  -- Disable treesitter highlighting
+  pcall(function()
+    vim.treesitter.stop(bufnr)
+  end)
+
+  -- Detach LSP clients (scheduled to be safe)
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then return end
+    local clients = vim.lsp.get_clients({ bufnr = bufnr })
+    for _, client in ipairs(clients) do
+      pcall(vim.lsp.buf_detach_client, bufnr, client.id)
+    end
+  end)
+
+  -- Buffer options
+  vim.bo[bufnr].swapfile = false
+  vim.bo[bufnr].undofile = false
+  vim.bo[bufnr].syntax = ""
+
+  -- Window options (safe: operates on current window only)
+  pcall(function()
+    vim.wo.foldmethod = "manual"
+    vim.wo.foldenable = false
+  end)
+
+  -- Disable indent-blankline
+  pcall(function()
+    require("ibl").setup_buffer(bufnr, { enabled = false })
+  end)
+
+  -- Disable local-highlight
+  pcall(function()
+    require("local-highlight").detach(bufnr)
+  end)
+
+  -- Disable nvim-ufo folding
+  pcall(function()
+    require("ufo").detach(bufnr)
+  end)
+
+  -- Disable matchparen — MUST be in vim.schedule to avoid E201 (#57)
+  vim.schedule(function()
+    if vim.fn.exists(":NoMatchParen") ~= 0 then
+      vim.cmd("NoMatchParen")
+    end
+  end)
+
+  -- Disable copilot
+  vim.b[bufnr].copilot_enabled = false
+
+  -- Disable nvim-cmp
+  pcall(function()
+    if package.loaded["cmp"] then
+      require("cmp").setup.buffer({ enabled = false })
+    end
+  end)
+
+  -- Disable auto-save
+  vim.b[bufnr].autosave_disable = true
+
+  vim.notify(
+    string.format("Big file detected (%s). Disabled expensive features.", reason),
+    vim.log.levels.INFO
+  )
+end
+
+-- Return a valid lazy.nvim plugin spec (no external plugin, just init logic)
 return {
   {
-    "LunarVim/bigfile.nvim",
+    -- Virtual plugin entry for lazy.nvim; no external dependency.
+    dir = vim.fn.stdpath("config"),
+    name = "bigfile-extras",
     lazy = false,
-    priority = 900, -- Load early to intercept file opens
+    priority = 900,
     config = function()
-      -- Size threshold in bytes (default 1MB)
-      local bigfile_size_threshold = vim.g.bigfile_size_threshold or (1024 * 1024) -- 1 MB
-
-      -- Binary file extensions to always treat as big/binary
-      local binary_extensions = {
-        "bin", "o", "obj", "exe", "a", "so", "dylib", "dll",
-        "class", "pyc", "pyo",
-        "pdf", "doc", "docx", "xls", "xlsx",
-        "png", "jpg", "jpeg", "gif", "bmp", "ico", "webp",
-        "mp3", "mp4", "avi", "mkv", "mov", "flv", "wmv", "wav", "flac",
-        "zip", "tar", "gz", "bz2", "xz", "7z", "rar",
-        "wasm", "dat",
-      }
-
-      --- Check if a buffer contains binary content (null bytes in first lines)
-      ---@param bufnr number
-      ---@return boolean
-      local function is_binary_content(bufnr)
-        local line_count = vim.api.nvim_buf_line_count(bufnr)
-        local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, 0, math.min(100, line_count), false)
-        if not ok then
-          return false
-        end
-        for _, line in ipairs(lines) do
-          if line:find("%z") then
-            return true
-          end
-          -- Check for high concentration of non-printable characters
-          local total = #line
-          if total > 0 then
-            local check_len = math.min(total, 512)
-            local non_printable = 0
-            for i = 1, check_len do
-              local byte = line:byte(i)
-              if byte < 32 and byte ~= 9 and byte ~= 10 and byte ~= 13 then
-                non_printable = non_printable + 1
-              end
-            end
-            if non_printable / check_len > 0.3 then
-              return true
-            end
-          end
-        end
-        return false
-      end
-
-      --- Check if file extension is a known binary type
-      ---@param filepath string
-      ---@return boolean
-      local function is_binary_extension(filepath)
-        local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
-        return vim.tbl_contains(binary_extensions, ext)
-      end
-
-      --- Disable expensive features for the current buffer
-      ---@param bufnr number
-      ---@param reason string
-      local function disable_expensive_features(bufnr, reason)
-        vim.b[bufnr].bigfile_detected = true
-        vim.b[bufnr].bigfile_reason = reason
-
-        -- Disable treesitter highlighting
-        pcall(function()
-          vim.treesitter.stop(bufnr)
-        end)
-
-        -- Detach LSP clients
-        vim.schedule(function()
-          local clients = vim.lsp.get_clients({ bufnr = bufnr })
-          for _, client in ipairs(clients) do
-            pcall(vim.lsp.buf_detach_client, bufnr, client.id)
-          end
-        end)
-
-        -- Disable various buffer-local features
-        vim.bo[bufnr].swapfile = false
-        vim.bo[bufnr].undofile = false
-
-        -- Disable syntax highlighting (fallback)
-        vim.bo[bufnr].syntax = ""
-
-        -- Disable folding for this buffer
-        pcall(function()
-          vim.wo.foldmethod = "manual"
-          vim.wo.foldenable = false
-        end)
-
-        -- Disable indent-blankline for this buffer
-        pcall(function()
-          if vim.g.is_plugin_loaded and vim.g.is_plugin_loaded("indent-blankline.nvim") then
-            require("ibl").setup_buffer(bufnr, { enabled = false })
-          end
-        end)
-
-        -- Disable local-highlight
-        pcall(function()
-          if vim.g.is_plugin_loaded and vim.g.is_plugin_loaded("local-highlight.nvim") then
-            require("local-highlight").detach(bufnr)
-          end
-        end)
-
-        -- Disable nvim-ufo folding
-        pcall(function()
-          if vim.g.is_plugin_loaded and vim.g.is_plugin_loaded("nvim-ufo") then
-            require("ufo").detach(bufnr)
-          end
-        end)
-
-        -- Disable matchparen
-        pcall(vim.cmd, "NoMatchParen")
-
-        -- Disable copilot for this buffer
-        vim.b[bufnr].copilot_enabled = false
-
-        -- Disable nvim-cmp for this buffer
-        pcall(function()
-          if package.loaded["cmp"] then
-            require("cmp").setup.buffer({ enabled = false })
-          end
-        end)
-
-        -- Disable auto-save for this buffer
-        vim.b[bufnr].autosave_disable = true
-
-        vim.notify(
-          string.format("Big file detected (%s). Disabled expensive features.", reason),
-          vim.log.levels.INFO
-        )
-      end
-
-      -- Configure bigfile.nvim
-      require("bigfile").setup({
-        filesize = math.floor(bigfile_size_threshold / (1024 * 1024)), -- Convert to MiB for bigfile.nvim
-        pattern = { "*" },
-        features = {
-          "indent_blankline",
-          "illuminate",
-          "lsp",
-          "treesitter",
-          "syntax",
-          "matchparen",
-          "vimopts",
-          -- filetype is intentionally NOT disabled so autocmds still work
-        },
-      })
-
-      -- Additional autocmd for binary detection (bigfile.nvim only handles size)
+      -- Binary file detection (BufReadPost) — Snacks bigfile only handles size
       vim.api.nvim_create_autocmd({ "BufReadPost" }, {
         group = vim.api.nvim_create_augroup("binary_file_detection", { clear = true }),
         callback = function(args)
@@ -193,7 +186,9 @@ return {
         end,
       })
 
-      -- Also intercept BufReadPre for very large files to prevent loading issues
+      -- BufReadPre precheck: for extremely large files (>10MB), set buffer
+      -- options before the file is fully loaded.
+      -- NOTE: No operations that change curbuf (like windo) are done here.
       vim.api.nvim_create_autocmd({ "BufReadPre" }, {
         group = vim.api.nvim_create_augroup("bigfile_precheck", { clear = true }),
         callback = function(args)
@@ -214,7 +209,7 @@ return {
         end,
       })
 
-      -- User command to check bigfile status
+      -- User command: show bigfile status for current buffer
       vim.api.nvim_create_user_command("BigFileInfo", function()
         local bufnr = vim.api.nvim_get_current_buf()
         local filepath = vim.api.nvim_buf_get_name(bufnr)
@@ -243,7 +238,7 @@ return {
         vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO)
       end, { desc = "Show big file detection info for current buffer" })
 
-      -- User command to force-enable features on current buffer
+      -- User command: force re-enable features on current buffer
       vim.api.nvim_create_user_command("BigFileOverride", function()
         local bufnr = vim.api.nvim_get_current_buf()
         vim.b[bufnr].bigfile_detected = false

--- a/config.nvim/lua/plugins/miscellaneous.lua
+++ b/config.nvim/lua/plugins/miscellaneous.lua
@@ -304,7 +304,69 @@ return {
       { "<leader>zz", function() Snacks.picker.zoxide({ pattern = vim.g.function_get_selected_content()}) end, desc = "Zoxide cwd navigation", mode = "v"},
     },
     opts = {
-      bigfile = { enabled = true },
+      bigfile = {
+        enabled = true,
+        size = 1024 * 1024, -- 1MB (matches bigfile_size_threshold)
+        ---@param ctx {buf: number, ft: string}
+        setup = function(ctx)
+          -- NoMatchParen MUST be in vim.schedule to avoid E201 (#57).
+          -- The root cause: NoMatchParen uses windo which iterates over Snacks
+          -- picker floating windows, changing curbuf during BufReadPre.
+          vim.schedule(function()
+            if vim.fn.exists(":NoMatchParen") ~= 0 then
+              vim.cmd("NoMatchParen")
+            end
+          end)
+
+          -- Window options (current window only, safe)
+          Snacks.util.wo(0, { foldmethod = "manual", statuscolumn = "", conceallevel = 0 })
+
+          -- Disable various plugins for this buffer
+          vim.b.minianimate_disable = true
+          vim.b.minihipatterns_disable = true
+          vim.b[ctx.buf].copilot_enabled = false
+          vim.b[ctx.buf].autosave_disable = true
+
+          -- Disable nvim-cmp
+          pcall(function()
+            if package.loaded["cmp"] then
+              require("cmp").setup.buffer({ enabled = false })
+            end
+          end)
+
+          -- Disable indent-blankline
+          pcall(function()
+            require("ibl").setup_buffer(ctx.buf, { enabled = false })
+          end)
+
+          -- Disable nvim-ufo
+          pcall(function()
+            require("ufo").detach(ctx.buf)
+          end)
+
+          -- Disable local-highlight
+          pcall(function()
+            require("local-highlight").detach(ctx.buf)
+          end)
+
+          -- Buffer options
+          vim.bo[ctx.buf].swapfile = false
+          vim.bo[ctx.buf].undofile = false
+
+          -- Mark as detected for BigFileInfo command
+          vim.b[ctx.buf].bigfile_detected = true
+          vim.b[ctx.buf].bigfile_reason = "size > 1MB (Snacks bigfile)"
+
+          -- Restore original syntax after bigfile filetype override.
+          -- Snacks sets ft="bigfile" which blocks treesitter/LSP attach,
+          -- but we still want basic syntax highlighting.
+          vim.schedule(function()
+            if vim.api.nvim_buf_is_valid(ctx.buf) then
+              vim.bo[ctx.buf].syntax = ctx.ft
+            end
+          end)
+        end,
+      },
       dashboard = { enabled = false },
       explorer = {
         enabled = true

--- a/tests/test_bigfile_consolidation.lua
+++ b/tests/test_bigfile_consolidation.lua
@@ -1,0 +1,157 @@
+-- Tests for bigfile consolidation (#57)
+-- Verifies:
+--   1. LunarVim/bigfile.nvim is no longer referenced
+--   2. NoMatchParen is wrapped in vim.schedule in both files
+--   3. Binary detection autocmd group exists
+--   4. BigFileInfo/BigFileOverride commands exist
+--   5. Snacks bigfile setup callback is properly configured
+
+local ok_count = 0
+local fail_count = 0
+local total = 0
+
+local function check(desc, condition)
+  total = total + 1
+  if condition then
+    ok_count = ok_count + 1
+    print("  ✓ " .. desc)
+  else
+    fail_count = fail_count + 1
+    print("  ✗ " .. desc)
+  end
+end
+
+-- Helper: read file content
+local function read_file(path)
+  local f = io.open(path, "r")
+  if not f then return nil end
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
+-- Determine repo root (script may be run from repo root or tests/ dir)
+local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or "./"
+local repo_root = script_dir:match("(.-)tests/") or script_dir .. "../"
+
+local bigfile_path = repo_root .. "config.nvim/lua/plugins/bigfile.lua"
+local misc_path = repo_root .. "config.nvim/lua/plugins/miscellaneous.lua"
+
+print("\n=== Test: bigfile consolidation (#57) ===\n")
+
+-- 1. LunarVim/bigfile.nvim is no longer referenced in bigfile.lua
+print("[1] LunarVim/bigfile.nvim removal")
+local bigfile_content = read_file(bigfile_path)
+assert(bigfile_content, "Could not read " .. bigfile_path)
+
+check("bigfile.lua does not reference LunarVim/bigfile.nvim",
+  not bigfile_content:find("LunarVim/bigfile%.nvim"))
+
+check("bigfile.lua does not require('bigfile')",
+  not bigfile_content:find('require%("bigfile"%)'))
+
+check("bigfile.lua does not call bigfile.setup()",
+  not bigfile_content:find('require%("bigfile"%).setup'))
+
+-- 2. NoMatchParen is wrapped in vim.schedule
+print("\n[2] NoMatchParen in vim.schedule (core fix for E201)")
+
+-- In bigfile.lua: NoMatchParen must appear inside a vim.schedule block
+local bigfile_schedule_block = bigfile_content:match("vim%.schedule%(function%(%).-NoMatchParen.-end%)")
+check("bigfile.lua: NoMatchParen is inside vim.schedule(function()...end)",
+  bigfile_schedule_block ~= nil)
+
+-- Verify there's no bare/synchronous NoMatchParen call outside vim.schedule
+-- Count all NoMatchParen occurrences and all that are inside vim.schedule
+local all_nomatchparen = {}
+for pos in bigfile_content:gmatch("()NoMatchParen") do
+  table.insert(all_nomatchparen, pos)
+end
+-- Every NoMatchParen in bigfile.lua should be either in a comment or inside vim.schedule
+local bare_calls = 0
+for _, pos in ipairs(all_nomatchparen) do
+  -- Get the line containing this occurrence
+  local line_start = bigfile_content:sub(1, pos):match(".*\n()") or 1
+  local line_end = bigfile_content:find("\n", pos) or #bigfile_content
+  local line = bigfile_content:sub(line_start, line_end)
+  -- Skip comments
+  if not line:match("^%s*%-%-") then
+    -- Check if it's inside a vim.schedule block (look backwards for vim.schedule)
+    local before = bigfile_content:sub(math.max(1, pos - 200), pos)
+    if not before:match("vim%.schedule%(function%(%)\n") then
+      bare_calls = bare_calls + 1
+    end
+  end
+end
+check("bigfile.lua: no bare (non-scheduled) NoMatchParen calls",
+  bare_calls == 0)
+
+-- In miscellaneous.lua: same check
+local misc_content = read_file(misc_path)
+assert(misc_content, "Could not read " .. misc_path)
+
+local misc_schedule_block = misc_content:match("vim%.schedule%(function%(%).-NoMatchParen.-end%)")
+check("miscellaneous.lua: NoMatchParen is inside vim.schedule(function()...end)",
+  misc_schedule_block ~= nil)
+
+-- 3. Binary detection autocmd exists
+print("\n[3] Binary file detection")
+check("bigfile.lua has binary_file_detection augroup",
+  bigfile_content:find('"binary_file_detection"') ~= nil)
+
+check("bigfile.lua has BufReadPost autocmd for binary detection",
+  bigfile_content:find('BufReadPost') ~= nil)
+
+check("bigfile.lua has binary_extensions table",
+  bigfile_content:find('binary_extensions') ~= nil)
+
+check("bigfile.lua has is_binary_content function",
+  bigfile_content:find('function is_binary_content') ~= nil)
+
+-- 4. User commands exist
+print("\n[4] User commands")
+check("bigfile.lua defines BigFileInfo command",
+  bigfile_content:find('"BigFileInfo"') ~= nil)
+
+check("bigfile.lua defines BigFileOverride command",
+  bigfile_content:find('"BigFileOverride"') ~= nil)
+
+-- 5. Snacks bigfile setup callback
+print("\n[5] Snacks bigfile configuration")
+check("miscellaneous.lua has Snacks bigfile setup function",
+  misc_content:find('setup = function%(ctx%)') ~= nil)
+
+check("miscellaneous.lua has bigfile size = 1024 * 1024",
+  misc_content:find('size = 1024 %* 1024') ~= nil)
+
+check("miscellaneous.lua disables copilot in bigfile setup",
+  misc_content:find('copilot_enabled = false') ~= nil)
+
+check("miscellaneous.lua restores syntax in vim.schedule",
+  misc_content:find('vim%.bo%[ctx%.buf%]%.syntax = ctx%.ft') ~= nil)
+
+-- 6. BufReadPre precheck
+print("\n[6] BufReadPre precheck")
+check("bigfile.lua has bigfile_precheck augroup",
+  bigfile_content:find('"bigfile_precheck"') ~= nil)
+
+check("bigfile.lua has BufReadPre autocmd",
+  bigfile_content:find('BufReadPre') ~= nil)
+
+-- 7. Lazy.nvim spec format
+print("\n[7] Lazy.nvim plugin spec format")
+check("bigfile.lua returns a table (plugin spec)",
+  bigfile_content:match("^return {") ~= nil or bigfile_content:match("\nreturn {") ~= nil)
+
+check("bigfile.lua uses dir-based spec (no external plugin URL)",
+  bigfile_content:find('dir = vim%.fn%.stdpath') ~= nil)
+
+-- Summary
+print(string.format("\n=== Results: %d/%d passed ===", ok_count, total))
+if fail_count > 0 then
+  print(string.format("FAILED: %d test(s) failed!", fail_count))
+  os.exit(1)
+else
+  print("ALL TESTS PASSED!")
+  os.exit(0)
+end


### PR DESCRIPTION
## Summary

Consolidates bigfile handling into Snacks bigfile configuration and removes the `LunarVim/bigfile.nvim` plugin dependency.

## Root Cause (#57)

When opening large files from Snacks picker, `LunarVim/bigfile.nvim` calls `NoMatchParen` synchronously during `BufReadPre`. The `:NoMatchParen` command internally uses `:windo` which iterates over all windows — including Snacks picker floating windows. This changes `curbuf` during the `BufReadPre` event, triggering `E201: *strftime* strftime` error.

## Changes

### `config.nvim/lua/plugins/bigfile.lua`
- **Removed** `LunarVim/bigfile.nvim` plugin declaration
- **Retained** binary file detection (by extension + content analysis) as independent `BufReadPost` autocmd
- **Retained** `BufReadPre` precheck for extremely large files (>10MB)
- **Retained** `BigFileInfo` / `BigFileOverride` user commands
- All `NoMatchParen` calls wrapped in `vim.schedule()` (**core fix**)
- Uses `dir`-based lazy.nvim spec (no external plugin)

### `config.nvim/lua/plugins/miscellaneous.lua`
- Expanded Snacks `bigfile` config with full `setup` callback:
  - `NoMatchParen` in `vim.schedule()` (avoids E201)
  - Window options via `Snacks.util.wo()`
  - Disables: cmp, ibl, ufo, local-highlight, copilot, auto-save
  - Buffer options: swapfile/undofile off
  - Restores original syntax highlighting after ft override
  - Sets `bigfile_detected`/`bigfile_reason` for `BigFileInfo`

### Tests
- `tests/test_bigfile_consolidation.lua`: 20 assertions verifying removal, vim.schedule wrapping, binary detection, commands, and spec format

Closes #57