### PR TITLE
fix: HTTP Runner v3 — buffer crash, output UX, timing prelude

### DIFF
--- a/nvim-runner/lua/nvim-runner/runner.lua
+++ b/nvim-runner/lua/nvim-runner/runner.lua
@@ -9,6 +9,9 @@ local M = {}
 -- Track the current running process
 M._current_runner = nil
 
+-- Track scratch buffers by filetype to avoid E95 (buffer name conflict)
+M._scratch_buffers = {}
+
 --- Safe string replacement that avoids gsub pattern/replacement special chars.
 --- Uses plain string.find to locate the pattern, then concatenates.
 --- Only replaces the first occurrence.
@@ -238,28 +241,67 @@ function M.run()
           local output_mode = runner.output or "inline"
 
           if output_mode == "split" then
+            -- JSON prettification options (not yet implemented):
+            -- 1. Pipe through `jq .` if available: cmd .. " | jq ."
+            -- 2. Use vim.json.decode + vim.json.encode(data, {indent=2})
+            -- 3. Set filetype of body portion to 'json' for treesitter highlighting
+            -- 4. Use `python3 -m json.tool` as fallback
+
             -- Create or reuse a scratch buffer for this filetype
             local ft = vim.bo[bufid].filetype or "output"
-            local scratch_name = "[nvim-runner: " .. ft .. "]"
 
-            -- Look for existing scratch buffer with this name
-            local scratch_bufnr = nil
-            for _, b in ipairs(vim.api.nvim_list_bufs()) do
-              if vim.api.nvim_buf_is_valid(b) and vim.api.nvim_buf_get_name(b) == scratch_name then
-                scratch_bufnr = b
-                break
-              end
+            -- Use module-level tracking to avoid E95 buffer name conflict
+            local scratch_bufnr = M._scratch_buffers[ft]
+
+            -- Validate it still exists
+            if scratch_bufnr and not vim.api.nvim_buf_is_valid(scratch_bufnr) then
+              scratch_bufnr = nil
+              M._scratch_buffers[ft] = nil
             end
 
             if not scratch_bufnr then
               scratch_bufnr = vim.api.nvim_create_buf(false, true)
-              vim.api.nvim_buf_set_name(scratch_bufnr, scratch_name)
+              M._scratch_buffers[ft] = scratch_bufnr
             end
 
             -- Set buffer options
             vim.bo[scratch_bufnr].buftype = "nofile"
             vim.bo[scratch_bufnr].swapfile = false
             vim.bo[scratch_bufnr].buflisted = false
+            vim.bo[scratch_bufnr].filetype = "http"
+
+            -- Bind q to close buffer + window
+            vim.api.nvim_buf_set_keymap(scratch_bufnr, 'n', 'q', '<cmd>bdelete<cr>', {
+              noremap = true, silent = true, desc = "Close HTTP response buffer"
+            })
+
+            -- For HTTP split output: move timing footer to prelude
+            if ft == "http" then
+              local lines_list = vim.split(return_text, "\n")
+              local timing_line = nil
+              local timing_idx = nil
+              -- Find the timing line (last line matching pattern)
+              for i = #lines_list, 1, -1 do
+                if lines_list[i]:match("^%-%-%- %d+ |") then
+                  timing_line = lines_list[i]
+                  timing_idx = i
+                  break
+                end
+              end
+              if timing_line and timing_idx then
+                table.remove(lines_list, timing_idx)
+                -- Build prelude: timing + separator + response
+                local prelude = { timing_line, string.rep("-", 40) }
+                -- Remove leading empty lines from response
+                while #lines_list > 0 and lines_list[1] == "" do
+                  table.remove(lines_list, 1)
+                end
+                for i = #prelude, 1, -1 do
+                  table.insert(lines_list, 1, prelude[i])
+                end
+                return_text = table.concat(lines_list, "\n")
+              end
+            end
 
             -- Clear and write content
             vim.api.nvim_buf_set_lines(scratch_bufnr, 0, -1, false, vim.split(return_text, "\n"))

--- a/nvim-runner/test_results.txt
+++ b/nvim-runner/test_results.txt
@@ -1,0 +1,74 @@
+nvim-runner test results
+Date: Thu 21 May 2026 07:55:02 PM CST
+Neovim: 0.11.6+ge8b87a554f
+Total: 68 passed, 0 failed, 1 skipped
+
+[PASS] config: options exist after setup
+[PASS] config: default timeout is 3000ms
+[PASS] config: default insert_result is true
+[PASS] config: python runner defined
+[PASS] config: lua runner defined
+[PASS] config: sh runner defined
+[PASS] config: nu runner defined
+[PASS] config: custom timeout override works
+[PASS] config: python runner still exists after merge
+[PASS] util: not in visual mode in headless
+[PASS] command: RunScript exists
+[PASS] command: RunTest exists
+[PASS] command: SetBufRunner exists
+[PASS] lua: basic return value execution
+[PASS] lua: vim.notify from executed code works
+[PASS] lua: syntax error is reported
+[PASS] lua: multiline execution succeeds
+[PASS] lua: nil return (prints 'lua executed.')
+[PASS] sh: basic echo output inserted into buffer
+[PASS] sh: stderr output captured
+[PASS] sh: multiline script execution
+[PASS] python: basic print output
+[PASS] python: multiline computation
+[PASS] python: unicode output
+[PASS] python: stderr captured
+[PASS] FIXED_BUG: venv-selector pcall protection - no crash without venv-selector
+[SKIP] nu: nushell not available
+[PASS] FIXED_BUG: timeout kills process (500ms timeout for sleep 30)
+[PASS] timeout: per-runner timeout override works
+[PASS] SetBufRunner: buffer runner set
+[PASS] SetBufRunner: sh entry created
+[PASS] SetBufRunner: runner is empty string
+[PASS] SetBufRunner: template contains custom text
+[PASS] SetBufRunner: error on empty filetype
+[PASS] buffer-local: custom runner template overrides default
+[PASS] no filetype: error message shown
+[PASS] unknown filetype: error message for unsupported type
+[PASS] RunTest: discovers vimtest files
+[PASS] RunTest: reports test results
+[PASS] RunTest: reports when no test files found
+[PASS] RunTest: handles erroring test files gracefully
+[PASS] kill_current: returns false when no runner active
+[PASS] kill_current: returns true when killing active runner
+[PASS] kill_current: runner is nil after kill
+[PASS] FIXED_BUG: race condition - old runner killed before new one starts
+[PASS] FIXED_BUG: tostring(obj.code) works correctly
+[PASS] FIXED_BUG: string(obj.code) would have errored (confirmed bug)
+[PASS] FIXED_BUG: vim.log.levels.INFO exists
+[PASS] FIXED_BUG: vim.log.level (without s) is nil - confirms original bug
+[PASS] FIXED_BUG: python timeout is 3000ms (was 3)
+[PASS] FIXED_BUG: nu timeout is 5000ms (was 5)
+[PASS] FIXED_BUG: default timeout is 3000ms
+[PASS] FIXED_BUG: original timeout logic crashes with string candidate
+[PASS] FIXED_BUG: fixed timeout logic handles string candidate safely
+[PASS] FIXED_BUG: fixed timeout logic works with number
+[PASS] FIXED_BUG: fixed timeout logic rejects 0
+[PASS] FIXED_BUG: fixed timeout logic rejects negative
+[PASS] FIXED_BUG: fixed timeout logic handles nil
+[PASS] empty buffer: no crash on empty sh buffer
+[PASS] empty buffer: no crash on empty lua buffer
+[PASS] special chars: no crash with quotes and shell chars
+[PASS] insert_result=false: output not inserted into buffer
+[PASS] function template: custom function template works
+[PASS] runner abort: runner function returning nil triggers abort message
+[PASS] template abort: template function returning nil triggers abort message
+[PASS] invalid runner: number runner type reported as error
+[PASS] invalid template: number template type reported as error
+[PASS] idempotency: multiple setup calls don't crash
+[PASS] idempotency: RunScript still exists after re-setup

--- a/nvim-runner/tests/results_fixes.txt
+++ b/nvim-runner/tests/results_fixes.txt
@@ -1,0 +1,37 @@
+nvim-runner fixes test results
+Date: Thu 21 May 2026 07:55:10 PM CST
+Total: 33 passed, 0 failed, 0 skipped
+
+[PASS] keymap-dedup: keymap registered after first setup
+[PASS] keymap-dedup: keymap count unchanged after re-setup
+[PASS] keymap-dedup: keymap count unchanged after third setup
+[PASS] keymap-dedup: old keymaps removed when changing keys
+[PASS] keymap-dedup: _registered_keymaps exists
+[PASS] keymap-dedup: _registered_keymaps has 2 entries
+[PASS] buf-validity: script finished after buffer closed
+[PASS] buf-validity: warned about closed buffer
+[PASS] buf-validity: no crash when buffer deleted during execution
+[PASS] timeout-api: default is 3000
+[PASS] timeout-api: set_timeout changes global timeout
+[PASS] timeout-api: set_timeout rejects negative value
+[PASS] timeout-api: set_timeout rejects zero
+[PASS] timeout-api: set_timeout rejects string
+[PASS] timeout-api: set_buf_timeout sets vim.b.runner_timeout
+[PASS] timeout-api: set_buf_timeout with 0 uses current buffer
+[PASS] timeout-api: set_buf_timeout rejects negative value
+[PASS] timeout-api: vim.b.runner_timeout settable directly
+[PASS] timeout-priority: falls back to global timeout
+[PASS] timeout-priority: runner timeout overrides global
+[PASS] timeout-priority: buffer-local timeout overrides runner timeout
+[PASS] timeout-priority: without buf-local, falls back to runner
+[PASS] timeout-priority: non-number buf-local skipped
+[PASS] timeout-priority: zero buf-local skipped
+[PASS] timeout-priority: negative buf-local skipped
+[PASS] timeout-priority: falls back to default 3000ms
+[PASS] RunnerTimeout: command exists
+[PASS] RunnerTimeout: sets buffer-local timeout
+[PASS] RunnerTimeout!: sets global timeout
+[PASS] RunnerTimeout: error on invalid value
+[PASS] timeout-integration: buffer-local timeout (500ms) overrides global (10s)
+[PASS] safe_replace-integration: Python % formatting works end-to-end
+[PASS] safe_replace-integration: Shell printf with % works

--- a/nvim-runner/tests/test_http_spec.lua
+++ b/nvim-runner/tests/test_http_spec.lua
@@ -1456,6 +1456,193 @@ do
 end
 
 -- ============================================
+-- Section 29: Scratch buffer reuse (E95 fix)
+-- ============================================
+
+io.write("\n--- scratch buffer reuse (E95 fix) ---\n\n")
+
+do
+  local runner = require("nvim-runner.runner")
+
+  -- Clear any tracked scratch buffers
+  runner._scratch_buffers = {}
+
+  -- Simulate the split output path: create a buffer and trigger the callback logic
+  -- We test the module-level tracking directly
+  local ft = "http"
+
+  -- First call: no buffer exists yet
+  local scratch_bufnr = runner._scratch_buffers[ft]
+  assert_nil(scratch_bufnr, "E95-fix: no scratch buffer tracked initially")
+
+  -- Create one
+  scratch_bufnr = vim.api.nvim_create_buf(false, true)
+  runner._scratch_buffers[ft] = scratch_bufnr
+  assert_true(vim.api.nvim_buf_is_valid(scratch_bufnr), "E95-fix: created scratch buffer is valid")
+
+  -- Second call: should reuse the same buffer (no E95)
+  local scratch_bufnr2 = runner._scratch_buffers[ft]
+  if scratch_bufnr2 and not vim.api.nvim_buf_is_valid(scratch_bufnr2) then
+    scratch_bufnr2 = nil
+    runner._scratch_buffers[ft] = nil
+  end
+  assert_eq(scratch_bufnr2, scratch_bufnr, "E95-fix: second call reuses same buffer (no E95)")
+
+  -- Third call: same buffer (stress test)
+  local scratch_bufnr3 = runner._scratch_buffers[ft]
+  if scratch_bufnr3 and not vim.api.nvim_buf_is_valid(scratch_bufnr3) then
+    scratch_bufnr3 = nil
+    runner._scratch_buffers[ft] = nil
+  end
+  assert_eq(scratch_bufnr3, scratch_bufnr, "E95-fix: third call still reuses same buffer")
+
+  -- Invalidate the buffer and verify recovery
+  vim.api.nvim_buf_delete(scratch_bufnr, { force = true })
+  local scratch_bufnr4 = runner._scratch_buffers[ft]
+  if scratch_bufnr4 and not vim.api.nvim_buf_is_valid(scratch_bufnr4) then
+    scratch_bufnr4 = nil
+    runner._scratch_buffers[ft] = nil
+  end
+  assert_nil(scratch_bufnr4, "E95-fix: deleted buffer is detected and cleared")
+
+  -- New buffer created after invalidation
+  local scratch_bufnr5 = vim.api.nvim_create_buf(false, true)
+  runner._scratch_buffers[ft] = scratch_bufnr5
+  assert_true(scratch_bufnr5 ~= scratch_bufnr, "E95-fix: new buffer created after old one deleted")
+  assert_true(vim.api.nvim_buf_is_valid(scratch_bufnr5), "E95-fix: new buffer is valid")
+
+  -- Cleanup
+  vim.api.nvim_buf_delete(scratch_bufnr5, { force = true })
+  runner._scratch_buffers = {}
+end
+
+-- ============================================
+-- Section 30: q keymap on scratch buffer
+-- ============================================
+
+io.write("\n--- q keymap on scratch buffer ---\n\n")
+
+do
+  -- Create a scratch buffer and set the keymap as runner.lua does
+  local scratch_bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_keymap(scratch_bufnr, 'n', 'q', '<cmd>bdelete<cr>', {
+    noremap = true, silent = true, desc = "Close HTTP response buffer"
+  })
+
+  -- Verify the keymap is set
+  local keymaps = vim.api.nvim_buf_get_keymap(scratch_bufnr, 'n')
+  local found_q = false
+  for _, km in ipairs(keymaps) do
+    if km.lhs == "q" then
+      found_q = true
+      assert_true(km.noremap == 1, "q-keymap: noremap is set")
+      assert_true(km.silent == 1, "q-keymap: silent is set")
+      break
+    end
+  end
+  assert_true(found_q, "q-keymap: q keymap is set on scratch buffer")
+
+  -- Cleanup
+  vim.api.nvim_buf_delete(scratch_bufnr, { force = true })
+end
+
+-- ============================================
+-- Section 31: Filetype set to http on scratch buffer
+-- ============================================
+
+io.write("\n--- filetype http on scratch buffer ---\n\n")
+
+do
+  -- Create a scratch buffer and set filetype as runner.lua does
+  local scratch_bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[scratch_bufnr].buftype = "nofile"
+  vim.bo[scratch_bufnr].filetype = "http"
+
+  assert_eq(vim.bo[scratch_bufnr].filetype, "http", "ft-http: filetype is http on scratch buffer")
+
+  -- Cleanup
+  vim.api.nvim_buf_delete(scratch_bufnr, { force = true })
+end
+
+-- ============================================
+-- Section 32: Timing line moved to prelude
+-- ============================================
+
+io.write("\n--- timing line prelude ---\n\n")
+
+do
+  -- Simulate the timing-prelude logic from runner.lua
+  local return_text = "\nHTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"result\": \"ok\"}\n--- 200 | 0.342s ---"
+
+  local ft = "http"
+  if ft == "http" then
+    local lines_list = vim.split(return_text, "\n")
+    local timing_line = nil
+    local timing_idx = nil
+    for i = #lines_list, 1, -1 do
+      if lines_list[i]:match("^%-%-%- %d+ |") then
+        timing_line = lines_list[i]
+        timing_idx = i
+        break
+      end
+    end
+    if timing_line and timing_idx then
+      table.remove(lines_list, timing_idx)
+      local prelude = { timing_line, string.rep("-", 40) }
+      while #lines_list > 0 and lines_list[1] == "" do
+        table.remove(lines_list, 1)
+      end
+      for i = #prelude, 1, -1 do
+        table.insert(lines_list, 1, prelude[i])
+      end
+      return_text = table.concat(lines_list, "\n")
+    end
+
+    -- Verify timing line is at top
+    local result_lines = vim.split(return_text, "\n")
+    assert_match(result_lines[1], "^%-%-%- %d+ |", "timing-prelude: timing line is first line")
+    assert_eq(result_lines[2], string.rep("-", 40), "timing-prelude: separator is second line")
+    assert_match(result_lines[3], "HTTP/1.1 200 OK", "timing-prelude: response headers follow separator")
+
+    -- Verify timing line is NOT at the end anymore
+    local last_line = result_lines[#result_lines]
+    assert_true(not last_line:match("^%-%-%- %d+ |"), "timing-prelude: timing line removed from end")
+  end
+end
+
+do
+  -- Test with different timing format
+  local return_text = "\nHTTP/1.1 404 Not Found\nContent-Type: text/plain\n\nNot Found\n--- 404 | 1.234s ---"
+  local lines_list = vim.split(return_text, "\n")
+  local timing_line = nil
+  local timing_idx = nil
+  for i = #lines_list, 1, -1 do
+    if lines_list[i]:match("^%-%-%- %d+ |") then
+      timing_line = lines_list[i]
+      timing_idx = i
+      break
+    end
+  end
+  assert_true(timing_line ~= nil, "timing-prelude-404: timing line detected")
+  assert_match(timing_line, "404", "timing-prelude-404: contains status code 404")
+  assert_match(timing_line, "1.234s", "timing-prelude-404: contains timing value")
+end
+
+do
+  -- Test with no timing line (edge case)
+  local return_text = "\nHTTP/1.1 200 OK\n\nbody content"
+  local lines_list = vim.split(return_text, "\n")
+  local timing_line = nil
+  for i = #lines_list, 1, -1 do
+    if lines_list[i]:match("^%-%-%- %d+ |") then
+      timing_line = lines_list[i]
+      break
+    end
+  end
+  assert_nil(timing_line, "timing-prelude-none: no timing line when absent (graceful)")
+end
+
+-- ============================================
 -- Summary
 -- ============================================
 


### PR DESCRIPTION
Fixes:
- E95 crash on repeated requests (buffer name conflict)
- `q` to close response buffer
- Filetype set to http for syntax highlighting
- Status code + timing moved to prelude with separator
- JSON prettification investigation (comment only)

Ref: #45