### PR TITLE
feat(ai): sidekick.nvim Copilot Next Edit Suggestions (NES)

### DIFF
--- a/config.nvim/lazy-lock.json
+++ b/config.nvim/lazy-lock.json
@@ -61,6 +61,7 @@
   "promise-async": { "branch": "main", "commit": "119e8961014c9bfaf1487bf3c2a393d254f337e2" },
   "rainbow-delimiters.nvim": { "branch": "master", "commit": "aab6caaffd79b8def22ec4320a5344f7c42f58d2" },
   "rustaceanvim": { "branch": "main", "commit": "12504405821c05874d2d1f6b5ec919f9808e2c99" },
+  "sidekick.nvim": { "branch": "main", "commit": "208e1c5b8170c01fd1d07df0139322a76479b235" },
   "snacks.nvim": { "branch": "main", "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b" },
   "sqlite.lua": { "branch": "master", "commit": "50092d60feb242602d7578398c6eb53b4a8ffe7b" },
   "todo-comments.nvim": { "branch": "main", "commit": "304a8d204ee787d2544d8bc23cd38d2f929e7cc5" },

--- a/config.nvim/lua/config/keymaps.lua
+++ b/config.nvim/lua/config/keymaps.lua
@@ -52,9 +52,17 @@ vim.keymap.set({ "n", "v" }, "<leader>-", "<cmd>split<cr><c-w>j")
 vim.keymap.set({ "n", "v" }, "<leader>|", "<cmd>vsplit<cr><c-w>l")
 vim.keymap.set({ "n", "v" }, "<leader>wd", "<c-w>q", { desc = "Close the current window." })
 vim.keymap.set({ "n", "v" }, "<esc>", function()
+  -- Layered <Esc>: the first press dismisses a pending sidekick NES suggestion;
+  -- once nothing is pending, <Esc> clears the search highlight (original behavior).
+  -- Requires sidekick nes.clear.esc = false so this map is the sole <Esc> handler.
+  local ok, nes = pcall(require, "sidekick.nes")
+  if ok and nes.have and nes.have() then
+    nes.clear()
+    return
+  end
   vim.cmd([[ noh ]])
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<esc>", true, false, true), "n", false)
-end, { desc = "Esc wrapper: no highlight with esc." })
+end, { desc = "Esc: clear NES suggestion, else no-highlight." })
 
 vim.keymap.set({ "n", "v" }, "<leader>ps", '"+p', { desc = "paste from the clipboard." })
 
@@ -327,7 +335,20 @@ end, { noremap = true, silent = true })
 
 -- Tab-related.
 vim.keymap.set("n", "<leader><tab>", "<cmd>tabnew<CR>", { noremap = true, silent = true })
-vim.keymap.set("n", "<tab>", "<cmd>FlipPinnedTab<cr>", { noremap = true, silent = true })
+-- <Tab> (normal): sidekick NES. If an edit is pending, jump to / apply it;
+-- otherwise request a fresh suggestion right now. Replaces FlipPinnedTab (rarely
+-- used) and the treesitter incremental-selection <Tab> (removed in plugins/lsp.lua).
+vim.keymap.set("n", "<tab>", function()
+  local ok, sidekick = pcall(require, "sidekick")
+  if not ok then
+    return
+  end
+  -- nes_jump_or_apply() returns truthy if it jumped/applied; falsy when nothing
+  -- was pending -> request a suggestion now.
+  if not sidekick.nes_jump_or_apply() then
+    require("sidekick.nes").update()
+  end
+end, { desc = "NES: jump/apply edit, else request suggestion", silent = true })
 vim.keymap.set("n", "d<tab>", "<cmd>tabclose<CR>", { noremap = true, silent = true })
 
 -- Migrate to normal-tabbing switching.

--- a/config.nvim/lua/plugins/ai.lua
+++ b/config.nvim/lua/plugins/ai.lua
@@ -53,6 +53,34 @@ return {
     end
   )(),
   {
+    -- sidekick.nvim: Copilot LSP "Next Edit Suggestions" (NES). Complements
+    -- copilot.vim's insert-mode inline completions (they coexist by mode).
+    -- Keymaps live centrally in lua/config/keymaps.lua: <Tab> jump/apply-or-
+    -- request, <Esc> dismiss (that is why nes.clear.esc is disabled below).
+    -- NES is normal-mode only: it triggers on leaving insert / normal-mode
+    -- edits and is cleared on InsertEnter / TextChangedI.
+    "folke/sidekick.nvim",
+    enabled = vim.g.modules.copilot and vim.g.modules.copilot.enabled,
+    event = "LspAttach",
+    opts = {
+      nes = {
+        -- Honor the same opt-outs copilot.vim uses (bigfile.lua /
+        -- miscellaneous.lua set vim.b.copilot_enabled = false), plus a
+        -- sidekick-specific global/per-buffer toggle.
+        enabled = function(buf)
+          if vim.b[buf].copilot_enabled == false then
+            return false
+          end
+          return vim.g.sidekick_nes ~= false and vim.b[buf].sidekick_nes ~= false
+        end,
+        -- <Esc> is handled centrally in keymaps.lua (layered clear), so let it
+        -- own the key instead of sidekick installing its own <Esc> handler.
+        clear = { esc = false },
+      },
+    },
+    -- No `keys`: <Tab>/<Esc> are defined in lua/config/keymaps.lua.
+  },
+  {
     -- Quick one-key AI modification helper.
     -- Addresses nvim-config#14: A quick one-key ai modification helper.
     -- Philosophy: keep it simple, select code → one key → AI edits in place.

--- a/config.nvim/lua/plugins/lsp.lua
+++ b/config.nvim/lua/plugins/lsp.lua
@@ -168,58 +168,8 @@ return {
         select_textobject("@class.inner", "textobjects")
       end, { desc = "Select inner class" })
 
-      -- Incremental selection (Tab/Shift-Tab) — replaces the removed
-      -- nvim-treesitter incremental_selection module.
-      -- Uses built-in vim.treesitter API to walk the node tree.
-      local _inc_sel_node = nil  -- tracks current node for incremental expansion
-
-      -- Helper: select a treesitter node in linewise visual mode
-      local function select_node(node)
-        if not node then return end
-        local start_row, _, end_row, end_col = node:range()
-        if end_col == 0 and end_row > start_row then
-          end_row = end_row - 1
-        end
-        vim.api.nvim_win_set_cursor(0, { start_row + 1, 0 })
-        vim.cmd("normal! V")
-        vim.api.nvim_win_set_cursor(0, { end_row + 1, 0 })
-      end
-
-      -- Init / expand selection (Tab)
-      vim.keymap.set("n", "<Tab>", function()
-        local node = vim.treesitter.get_node()
-        if not node then return end
-        _inc_sel_node = node
-        select_node(node)
-      end, { desc = "Init treesitter incremental selection" })
-
-      vim.keymap.set("x", "<Tab>", function()
-        if not _inc_sel_node then return end
-        local parent = _inc_sel_node:parent()
-        if parent then
-          _inc_sel_node = parent
-          select_node(parent)
-        end
-      end, { desc = "Expand treesitter selection to parent node" })
-
-      -- Shrink selection (Shift-Tab)
-      vim.keymap.set("x", "<S-Tab>", function()
-        if not _inc_sel_node then return end
-        -- Find the first named child to shrink to
-        local child = _inc_sel_node:named_child(0)
-        if child then
-          _inc_sel_node = child
-          select_node(child)
-        end
-      end, { desc = "Shrink treesitter selection to child node" })
-
-      -- Reset tracked node when leaving visual mode
-      vim.api.nvim_create_autocmd("ModeChanged", {
-        pattern = "[vV\x16]*:n",
-        callback = function()
-          _inc_sel_node = nil
-        end,
-      })
+      -- Incremental-selection <Tab>/<S-Tab> maps removed on purpose: <Tab> is
+      -- now bound to sidekick NES in normal mode (see lua/config/keymaps.lua).
     end,
   },
   {
@@ -285,6 +235,12 @@ return {
 
       -- Start LSP inlay hints
       vim.lsp.inlay_hint.enable(true)
+
+      -- Copilot LSP for sidekick NES is provided by copilot.vim itself: it starts
+      -- a "GitHub Copilot" vim.lsp client (autoload/copilot/client.vim ->
+      -- _copilot.lsp_start_client -> vim.lsp.start) that already supports
+      -- copilotInlineEdit / Next Edit Suggestions. sidekick.is_copilot() matches it
+      -- by name, so no extra LSP config is needed here; auth is via :Copilot setup.
     end,
   },
   {

--- a/docs/sidekick-nes-investigation.md
+++ b/docs/sidekick-nes-investigation.md
@@ -1,0 +1,111 @@
+# sidekick.nvim (Copilot Next Edit Suggestions) — integration & investigation
+
+## Goal
+
+Add [folke/sidekick.nvim](https://github.com/folke/sidekick.nvim) for Copilot
+**Next Edit Suggestions (NES)** alongside the existing `copilot.vim` inline
+completion. NES is complementary to inline completion, not a replacement:
+
+| | Inline completion (copilot.vim) | NES (sidekick.nvim) |
+|---|---|---|
+| Where | insert mode, ghost text at cursor | normal mode, diff/edit anywhere in file |
+| When | as you type | after you *finish* an edit that implies a follow-up |
+| Trigger events | insert | `ModeChanged i:n`, `TextChanged`; cleared on `InsertEnter`/`TextChangedI` |
+
+## Keymap design (normal mode)
+
+NES lives in normal mode (it is cleared on `InsertEnter`/`TextChangedI`), so the
+maps are normal-mode only, in `lua/config/keymaps.lua`:
+
+- **`<Tab>`** — if a suggestion is pending, `nes_jump_or_apply()` (jump, then
+  apply on the next press); otherwise `require("sidekick.nes").update()`
+  (request one now). Replaces the rarely-used `FlipPinnedTab` and the
+  treesitter incremental-selection `<Tab>` (removed from `plugins/lsp.lua`).
+- **`<Esc>`** — layered: first press dismisses a pending suggestion
+  (`nes.clear()`), otherwise falls back to the original `:noh` behavior.
+  `nes.clear.esc = false` is set so this map is the sole `<Esc>` handler.
+
+Both maps are `pcall`-guarded, so they are safe no-ops if sidekick is absent.
+
+## LSP wiring — what changed and why
+
+sidekick is only an *NES client*; it needs a `copilot-language-server` LSP
+client attached. Key finding during integration:
+
+- **`copilot.vim` already starts its own `vim.lsp` client named
+  `"GitHub Copilot"`** (`autoload/copilot/client.vim` →
+  `_copilot.lsp_start_client` → `vim.lsp.start`).
+- sidekick's `require("sidekick.config").is_copilot()` matches any client whose
+  name contains `copilot` (case-insensitive), so it uses copilot.vim's client
+  automatically.
+- An earlier attempt registered a **second, dedicated** `copilot` client via
+  `vim.lsp.config`/manual attach. This was redundant and created a
+  duplicate-client hazard (`get_client()[1]` becomes ambiguous), so it was
+  removed. `plugins/lsp.lua` now just documents that copilot.vim provides the
+  client; auth is via `:Copilot setup`.
+
+Notes for other setups:
+- `vim.lsp.enable("copilot")` only auto-attaches a config that declares
+  `filetypes`; the canonical `lsp/copilot.lua` omits them, so a bare `enable()`
+  never attaches — you must drive attachment yourself or list filetypes.
+- Older `nvim-lspconfig` pins predate `lsp/copilot.lua` (added 2025-08), so
+  `vim.lsp.enable("copilot")` warns "config not found" there.
+
+## NES returns no suggestions — root-cause investigation
+
+Symptom: everything loads, `:Copilot status = Ready`, inline completion works,
+but `require("sidekick.nes").have()` is always `false` and `<Tab>` does nothing.
+
+To settle it, the sandbox Copilot was authenticated (device flow) and
+`textDocument/copilotInlineEdit` was exercised directly. Findings:
+
+| Layer | Result |
+|---|---|
+| Auth | signed in |
+| Network / API | inline completion returns items (API reachable) |
+| NES feature flag | server sends `ide_enable_copilot_nes_nonfree_enabled = true` |
+| LSP client attaches, sidekick matches it | yes |
+| Request shape (matches copilot-lsp & sidekick exactly) | yes |
+| `textDocument/copilotInlineEdit` result | **`edits: []` (empty), `err = nil`** |
+
+The empty NES result reproduced across **all** of the following, i.e. it is not
+a config variable:
+
+- copilot.vim's `"GitHub Copilot"` client **and** a dedicated client on the
+  latest standalone `copilot-language-server` (1.519/1.520);
+- `context.triggerKind` = none / 1 / 2, with and without a `context` field;
+- `settings.github.copilot.nextEditSuggestions.enabled = true` +
+  `workspace/didChangeConfiguration`;
+- **real typed edits** (`ciw` rename generating genuine `didChange`), polled
+  6× over ~9s;
+- `didFocus` sent before the request (required by the protocol);
+- editor identity `editorInfo`/`editorPluginInfo` = `Neovim` / `vscode` /
+  `copilot.vim`.
+
+### Conclusion
+
+The Neovim / sidekick / copilot **configuration is correct and complete**.
+`have() == false` faithfully reflects that the Copilot backend returns **no**
+Next-Edit for this account/context — despite `inlineCompletion` working and the
+NES feature flag being enabled. This is **server-side**, outside Neovim's
+control.
+
+### Suggested follow-up (server-side)
+
+1. Reproduce NES in **VS Code** with the same account:
+   - also empty → account/plan/policy/rollout issue (check
+     `github.com/settings/copilot`, org Copilot policy; the `nonfree` flag hints
+     at an entitlement nuance) — raise with GitHub if needed;
+   - works in VS Code but not Neovim → a protocol delta worth diffing the raw
+     `copilotInlineEdit` payloads.
+2. Nothing further is required on the Neovim side; when the backend starts
+   returning edits, sidekick surfaces them automatically via the existing
+   `<Tab>`/`<Esc>` maps.
+
+## Files changed
+
+- `lua/config/keymaps.lua` — normal-mode `<Tab>`/`<Esc>` NES maps.
+- `lua/plugins/ai.lua` — `folke/sidekick.nvim` spec (NES only, `clear.esc=false`).
+- `lua/plugins/lsp.lua` — removed treesitter incremental-selection `<Tab>`/
+  `<S-Tab>`; documented that copilot.vim supplies the LSP client.
+- `lazy-lock.json` — pin `sidekick.nvim`.


### PR DESCRIPTION
## Summary
Adds **folke/sidekick.nvim** for Copilot **Next Edit Suggestions (NES)**, alongside the existing `copilot.vim` inline completion (complementary, not a replacement).

### Changes
- **keymaps**: normal-mode `<Tab>` = jump/apply pending NES else request one; `<Esc>` = dismiss pending NES else original `:noh`. Replaces the rarely-used `FlipPinnedTab`.
- **ai.lua**: `folke/sidekick.nvim` spec (NES only; `nes.clear.esc=false` so the central `<Esc>` owns the key).
- **lsp.lua**: remove treesitter incremental-selection `<Tab>`/`<S-Tab>` (frees `<Tab>`); document that `copilot.vim` already provides the copilot `vim.lsp` client sidekick uses (no dedicated client needed).
- **lazy-lock**: pin `sidekick.nvim`.
- **docs/sidekick-nes-investigation.md**: full writeup.

### Investigation / findings (why NES shows nothing yet)
Verified end-to-end on an authenticated instance:
- auth OK; network OK (**inline completion returns items**); NES feature flag on (`ide_enable_copilot_nes_nonfree_enabled = true`); client attaches; request shape matches copilot-lsp & sidekick.
- **`textDocument/copilotInlineEdit` returns `edits: []` (empty)** across: copilot.vim's client and a dedicated latest-server (1.520) client; `triggerKind` none/1/2; `nextEditSuggestions.enabled=true`+`didChangeConfiguration`; real typed edits polled 6×; `didFocus` sent; editor identity Neovim/vscode/copilot.vim.

**Conclusion:** the Neovim/sidekick/copilot config is correct and complete. `have()==false` faithfully reflects that the Copilot backend returns no Next-Edit for this account/context — a **server-side/account** matter (compare with VS Code NES on the same account; check Copilot settings/policy). When the backend returns edits, sidekick surfaces them via the `<Tab>`/`<Esc>` maps automatically.

Note: excludes unrelated concurrent working-tree edits (`ai.lua` `all_theirs`→`accept_theirs`, `lazy-lock` `rustaceanvim` branch flip).
